### PR TITLE
Django 1.10 max_length fix 

### DIFF
--- a/django_boto/s3/storage.py
+++ b/django_boto/s3/storage.py
@@ -148,7 +148,7 @@ class S3Storage(Storage):
 
         return name
 
-    def get_available_name(self, name):
+    def get_available_name(self, name, max_length=None):
         """
         Returns a filename that's free on the target storage system, and
         available for new content to be written to.


### PR DESCRIPTION
Hi, 
according to link below, I fixed crash for django 1.10.
Please merge it to master.

https://docs.djangoproject.com/en/1.10/releases/1.8/#support-for-the-max-length-argument-on-custom-storage-classes

Storage subclasses should add max_length=None as a parameter to get_available_name() and/or save() if they override either method. Support for storages that do not accept this argument will be removed in Django 1.10.
